### PR TITLE
[EN] Fixed an ambigious rule for multiline statements

### DIFF
--- a/javascript.md
+++ b/javascript.md
@@ -418,7 +418,7 @@ baz + ''
 
 ##Multi-Line Statements
   * If a statement is longer than the maximum [line length](#general), it is split into several lines and properly indented.
-  * Operators should be placed in the end of the line:
+  * Lines of the statement should be split after an operator:
 
 ```javascript
 var debt = this.calculateBaseDebt() + this.calculateSharedDebt() + this.calculateDebtPayments() +


### PR DESCRIPTION
The previous version of this rule is ambiguous.